### PR TITLE
Fix consecutive JSX transforms

### DIFF
--- a/src/bound_html.ts
+++ b/src/bound_html.ts
@@ -26,7 +26,7 @@ export function setHTMLContext(context: HTMLContext): void {
 function applyTransforms(type: string, props: any, children: any[]): any {
   let args = [type, props, children];
   for (const transform of currentHTMLContext.jsxTransforms) {
-    args = transform(type, props, children);
+    args = transform(args[0], args[1], args[2]);
   }
   return currentHTMLContext.currentFactory(args[0], args[1], ...args[2]);
 }

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -109,11 +109,11 @@ describe('htmdx', () => {
       ReactDOM.render(
         htmdx(simpleMarkdown, React.createElement, {
           jsxTransforms: [
-            (props, type, children) => {
+            (type, props, children) => {
               if (children && children[0] === 'Hello World') {
-                children[0] = 'Foo';
+                return ["h2", { ...props, name: "foo" }, ['Foo']];
               }
-              return [props, type, children];
+              return [type, props, children];
             },
           ],
         }),
@@ -122,7 +122,9 @@ describe('htmdx', () => {
       expect(root.innerHTML).not.toMatch(
         /<h1 id="hello-world">Hello World<\/h1>/
       );
-      expect(root.innerHTML).toMatch(/<h1 id="hello-world">Foo<\/h1>/);
+      expect(root.innerHTML).toMatch(
+        /<h2 id="hello-world" name="foo">Foo<\/h2>/
+      );
     });
     it('should not transform class to className outside of code tags if disabled', () => {
       const result: string[] = [];


### PR DESCRIPTION
This PR fixes consecutive JSX transforms. The problem surfaced when I wanted to transform the tag and properties of a virtual node and lies in `bound_html.ts`:

https://github.com/michael-klein/htmdx/blob/738b32530c0da7fd00fe888a40971b3f7a15224b/src/bound_html.ts#L26-L31

The `args` are not re-used inside the loop which means the original `type`, `props` and `children` are passed to the transforms over and over again and only the last transform will be effectively applied. This PR passes the `args` to the transforms. I also adjusted the simple JSX transforms test to test for changes of `type` and `props`.

On a side note: awesome library! I'm using it server-side to transform MDX to Preact virtual node representation, serialize them into JSON and request that on the client side to decouple content from logic. Works amazingly well!