### PR TITLE
Fix rendering of code blocks with backticks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,10 @@ function markedToReact(m: string, h: JSXFactory, options: HtmdxOptions): any {
   });
 
   // eslint-disable-next-line
-  return new Function('html', 'return html`' + m + '`').call(thisValue, html);
+  return new Function(
+    'html',
+    'return html`' + m.replace(/`/g, "\\\`") + '`'
+  ).call(thisValue, html);
 }
 
 function decodeHTML(m: string): string {

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -58,6 +58,16 @@ describe('htmdx', () => {
     expect(root.innerHTML).toMatch(/<h1 id="hello-world">Hello World<\/h1>/);
     expect(root.innerHTML).toMatch(/<pre><code>function SomeComponent\(\) {/);
   });
+  it('renders code blocks with backticks', () => {
+    ReactDOM.render(htmdx(`
+# Hello World
+\`\`\`
+Code with \`backticks\`
+\`\`\`
+    `, React.createElement), root);
+    expect(root.innerHTML).toMatch(/<h1 id="hello-world">Hello World<\/h1>/);
+    expect(root.innerHTML).toMatch(/<pre><code>Code with \`backticks\`/);
+  });
 
   describe('class transforms', () => {
     it('should transform class to className outside of code tags by default', () => {


### PR DESCRIPTION
This PR fixes the rendering of code blocks that contain backticks. The line causing the problem is:

https://github.com/michael-klein/htmdx/blob/460ed4a10635648dce8ee895c7a9f5bd23ed76e4/src/index.ts#L36

If `m` contains backticks, `htmdx` errors with:

```
(node:304) UnhandledPromiseRejectionWarning: SyntaxError: Unexpected identifier
    at new Function (<anonymous>)
    ...
```

... which makes sense, as the string is prematurely terminated by the backtick contained in the parsed Markdown. This PR adds a test to reproduce the problem and fixes it by escaping backticks.

I don't really know why you create a function from a string, so this part of the code may be worth revisiting.